### PR TITLE
Interim bugfixes

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.15"
+__version__ = "2.2.1"
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/meshiphi/mesh_generation/aggregated_cellbox.py
+++ b/meshiphi/mesh_generation/aggregated_cellbox.py
@@ -167,7 +167,13 @@ class AggregatedCellBox:
         """
         shapely_boundary = self.boundary.to_polygon()
         point = Point(long, lat)
-        return shapely_boundary.contains(point)
+        point_within_bounds = shapely_boundary.contains(point)
+        point_on_bounds     = shapely_boundary.boundary.contains(point)
+        point_on_north_edge = shapely_boundary.bounds[2] == point.x
+        point_on_east_edge  = shapely_boundary.bounds[3] == point.y
+        
+        return (point_within_bounds or \
+                (point_on_bounds and (point_on_north_edge or point_on_east_edge)))
     
     def __eq__(self, other):
 

--- a/meshiphi/mesh_generation/environment_mesh.py
+++ b/meshiphi/mesh_generation/environment_mesh.py
@@ -136,7 +136,6 @@ class EnvironmentMesh:
                 cellbox_index (str) - Cellbox index containing the point
         """
         inside_cell = [agg_cell.contains_point(point[0],point[1]) for agg_cell in self.agg_cellboxes]
-
         if any(inside_cell):
             indices = np.where(inside_cell)[0]
             if len(indices) > 1:

--- a/meshiphi/mesh_generation/environment_mesh.py
+++ b/meshiphi/mesh_generation/environment_mesh.py
@@ -136,6 +136,7 @@ class EnvironmentMesh:
                 cellbox_index (str) - Cellbox index containing the point
         """
         inside_cell = [agg_cell.contains_point(point[0],point[1]) for agg_cell in self.agg_cellboxes]
+
         if any(inside_cell):
             indices = np.where(inside_cell)[0]
             if len(indices) > 1:


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2025-03-03
Version Number: 2.2.1

## Description of change
Patching bug where north and east cellbox boundaries not included within the cellbox, changing to include them to be more in line with PolarRoute

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
[interim_bugfixes.log](https://github.com/user-attachments/files/19053129/interim_bugfixes.log)

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
